### PR TITLE
2026 Tournament Updates & Usage Tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TedTournament()
 
-TedTournament() is a custom function for Google Sheets which returns data for March Madness (NCAA Division I Basketball Championship) games. Currently, this function supports data for 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025 for men's and women's tournaments.
+TedTournament() is a custom function for Google Sheets which returns data for March Madness (NCAA Division I Basketball Championship) games. Currently, this function supports data for 2026, 2025, 2024, 2023, 2022, 2021, 2020, 2019, 2018, 2017, 2016, 2015, 2014 for men's and women's tournaments.
 
 ## Installation
 
@@ -79,11 +79,31 @@ If you're building you're own custom bracket and want to use my data, consider p
 In any tab in your own spreadsheet use the following:
 
 ```code()
-=importrange("1DyuuT9zPSh9RdzrAF_1bY6HhyuYKckL3E6wr-sGKZTs","Men 2025 Tournament Data!A:Z")
+=importrange("1DyuuT9zPSh9RdzrAF_1bY6HhyuYKckL3E6wr-sGKZTs","Men 2026 Tournament Data!A:Z")
 ```
 
 * Be sure you [authorize access](https://support.google.com/docs/answer/3093340?hl=en#zippy=%2Cpermission-access) if you're getting an error.
 * To pull in other years or gender simply change the "Men" to "Women" and the year to a year supported by TedTournament().
+
+## Privacy and Usage Tracking
+
+In version 2.7.0, an anonymous usage tracking feature was introduced to tally how many unique spreadsheets are actively using the custom function and the templates during each tournament season.
+
+**Function Usage Tracking:**
+When you use the `=TedTournament()` formula, the script implicitly pings an anonymous usage log with:
+* A randomly generated ID (e.g., `sheet_abc123`)
+* The script version (e.g., `2.7.0`)
+* The requested league
+* The requested year
+
+**Template Usage Tracking:**
+If you use the standalone templates linked below, they also contain an anonymous tracker that logs:
+* A randomly generated ID (e.g., `sheet_abc123`)
+* The template version (e.g., `Template_2026_Initial` or `Template_2026_Active`)
+* The selected league 
+* The selected year
+
+**This feature does not collect or track any personal information (no emails, no names, no bracket selections).**
 
 ## Contributing
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
@@ -93,7 +113,11 @@ Pull requests are welcome. For major changes, please open an issue first to disc
 
 ## Google Sheets Templates
 
-I maintain Google Sheets Templates for managing Individual Brackets or a Group of Brackets as a Bracket Manager. The below links will create your own private copy of the files. See the INSTRUCTIONS tab on each sheet for how to use them. You'll get a warning that says "The attached Apps Script file and functionality will also be copied. This is because the TedTournament() function comes pre-installed. To review the script, click on View Apps Script file when making the copy if you are unsure.
+I maintain Google Sheets Templates for managing Individual Brackets or a Group of Brackets as a Bracket Manager. The below links will create your own private copy of the files. **The most up-to-date version of both templates is currently Version 10.**
+
+**Note on Copying:** When you click the links below, Google will show a warning: *"The attached Apps Script file and functionality will also be copied."* **This is completely normal and safe.** It appears because the `TedTournament()` script is pre-installed in the template to support the tournament data functions, and to anonymously track active usage of the template and functions. As detailed in the *Privacy and Usage Tracking* section above, the script only logs a randomly generated ID, the template version, the requested league, and the year. If you'd like to verify this code before copying, you can click "View Apps Script file" right on the copy screen.
+
+**Note on Formulas:** You may also see a yellow bar below the menus that says *"Warning: Some formulas are trying to send and receive data from external parties."* This is a standard Google Sheets security feature that appears whenever a spreadsheet uses `IMPORTRANGE` or `IMPORTDATA` functions to pull in data or communicate with the backend tracking script. You can safely click **Allow access**.
 
 [Single Bracket Template](https://docs.google.com/spreadsheets/d/1izjBEQ_FIU0dJ2Z1exWMY2FwpmDP6AqHYxlldD6xhO4/copy) <--clicking on this link will open a new private copy only you have access to. Once the teams for the Tournament are set, pick your winners, sit back, and enjoy the show! The bracket will automatically update with winners and calculate winning scores. You can also use this template in conjunction with the group template below. See the HELP tabs on each template for how to use them together.
 

--- a/TedTournament.gs
+++ b/TedTournament.gs
@@ -1,13 +1,14 @@
 /*====================================================================================================================================*
   TedTournament by Ted Juch and Adam Lusk
  *====================================================================================================================================*
-  Version:      2.6.0
+  Version:      2.7.0
   Project Page: https://github.com/TedJuch/TedTournament
   License:      GNU General Public License, version 3 (GPL-3.0) 
                 http://www.opensource.org/licenses/gpl-3.0.html
   ------------------------------------------------------------------------------------------------------------------------------------
   Change Log:
   
+  2.7.0   Added support for the 2026 tournaments, dynamic API caching based on season dates to improve performance, and an anonymous usage ping to track active templates.
   2.6.0   Added support for the 2025 tournaments
   2.5.0   Added support for the 2024 tournaments
   2.4.2   Added new attributes: Top Team Char6, Bottom Team Char6, Winning Team Char6, Losing Team Char6
@@ -21,8 +22,12 @@
  *====================================================================================================================================*/
 
 function TedTournament(league, year, round, game, colNumber) {
+  trackUsage(league, year); // Anonymous tracker to count active spreadsheets (pings once per 6 hours)
+
   var key = "1DyuuT9zPSh9RdzrAF_1bY6HhyuYKckL3E6wr-sGKZTs"
-  var sheetMap = {"Women 2025 Tournament Data": 219886598,
+  var sheetMap = {"Women 2026 Tournament Data": 1726926731,
+                  "Men 2026 Tournament Data": 107716179,
+                  "Women 2025 Tournament Data": 219886598,
                   "Men 2025 Tournament Data": 914813182,
                   "Women 2024 Tournament Data": 2079808804,
                   "Men 2024 Tournament Data": 448317216,
@@ -47,25 +52,62 @@ function TedTournament(league, year, round, game, colNumber) {
                   "Women 2014 Tournament Data": 856902930,
                   "Men 2014 Tournament Data": 855551724};
   var sheetName = league + " " + year + " Tournament Data";
-  var gameData = getValuesPublic(key, sheetMap[sheetName], "A1:Z68");
+  var gid = sheetMap[sheetName];
+  
+  if (!gid) {
+    return "Unsupported league or year.";
+  }
+  
+  var gameData = getValuesPublicCached(key, gid, "A1:Z68");
  
-  for (var i = 0; i < gameData.length; i++)
-    if (gameData[i][1] == round && gameData[i][2] == game)
+  for (var i = 0; i < gameData.length; i++) {
+    if (gameData[i][1] == round && gameData[i][2] == game) {
       return gameData[i][colNumber + 2];
+    }
+  }
   
   return "Combination not found.";
 }
  
-function getValuesPublic(key, gid, range) {
+function getValuesPublicCached(key, gid, range) {
+  var cache = CacheService.getScriptCache();
+  var cacheKey = "TourneyData_" + gid + "_" + range;
+  var cachedData = cache.get(cacheKey);
+
+  if (cachedData != null) {
+    return JSON.parse(cachedData); 
+  }
+
   var content = UrlFetchApp.fetch("https://spreadsheets.google.com/tq?&tq=&key=" + key + "&gid=" + gid + "&range=" + range);
   var rows = (JSON.parse(/({.+})[^}]*$/.exec(content)[1])).table.rows;
   var output = [], temp;
+  
   for (var i = 0, length = rows.length; i < length; i++) {
     temp = [];
-    for (var j = 0, width = rows[i].c.length; j < width; j++)
+    for (var j = 0, width = rows[i].c.length; j < width; j++) {
       temp.push(rows[i].c[j] ? rows[i].c[j].v || "" : "");
+    }
     output.push(temp);
   }
+  
+  // Determine cache duration based on the date
+  var currentDate = new Date();
+  var cacheDuration = 21600; // Default to 6 hours (21600 seconds) in the off-season. Max is 6 hours
+  
+  // Define the exact tournament window (Months are 0-indexed: 2 = March, 3 = April)
+  // 2026 Tournament: March 15th to April 7th (covering the entire Men's and Women's schedules)
+  var tournamentStart = new Date(currentDate.getFullYear(), 2, 15); 
+  // Add a 1-day buffer (April 7th) to ensure late-night championship games on the 6th are fully covered
+  var tournamentEnd = new Date(currentDate.getFullYear(), 3, 7);
+  
+  // If the current date is within the tournament window, cache for only 60 seconds
+  if (currentDate >= tournamentStart && currentDate <= tournamentEnd) {
+    cacheDuration = 60;
+  }
+  
+  // Cache the result dynamically 
+  cache.put(cacheKey, JSON.stringify(output), cacheDuration); 
+  
   return output;
 }
  
@@ -74,4 +116,85 @@ function onInstall(e) {
 }
  
 function onOpen(e) {
+}
+
+function trackUsage(league, year) {
+  var cache = CacheService.getScriptCache();
+  var pingCacheKey = "TedTournament_Ping_" + league + "_" + year;
+  
+  // Only ping once every 6 hours (or if the cache drops) to avoid spamming the form
+  if (cache.get(pingCacheKey) != null) {
+    return;
+  }
+
+  // Prevent race conditions when 60+ spreadsheet formulas calculate at the exact same millisecond
+  var lock = LockService.getScriptLock();
+  // Try to acquire a lock for up to 1 second. If we can't, another cell is already tracking, so exit.
+  if (!lock.tryLock(1000)) {
+    return;
+  }
+  
+  try {
+    // Check cache one more time in case another cell just finished and populated it
+    if (cache.get(pingCacheKey) != null) {
+      return;
+    }
+    
+    // Set the cache IMMEDIATELY so any newly starting cells skip this entirely
+    cache.put(pingCacheKey, "pinged", 21600); 
+
+    var props = PropertiesService.getDocumentProperties();
+    var uid = props.getProperty("TedTournament_UID");
+    
+    // Generate a permanent, random anonymous ID for this spreadsheet if it doesn't have one
+    if (!uid) {
+      uid = "sheet_" + Math.random().toString(36).substring(2, 12);
+      props.setProperty("TedTournament_UID", uid);
+    }
+    
+    // Post the ID to the hidden Google Form
+    var formUrl = "https://docs.google.com/forms/d/e/1FAIpQLSfWNl-35dRt_UlggVqCqzpkMUsmVW2btfPdSp47fM3iEZ3sXQ/formResponse";
+    var payload = {
+      "entry.2037412024": "Formula",
+      "entry.1548934140": uid,
+      "entry.368804083": "2.7.0",
+      "entry.977408474": league || "Unknown",
+      "entry.1183376038": year || "Unknown"
+    };
+    
+    var options = {
+      "method": "post",
+      "payload": payload,
+      "muteHttpExceptions": true // If the form fetch fails, don't crash the bracket formulas
+    };
+    
+    UrlFetchApp.fetch(formUrl, options);
+    
+  } catch (e) {
+    // Fail silently
+  } finally {
+    // Always release the lock when done
+    lock.releaseLock();
+  }
+}
+
+// Zero-Warning UID Generator for Standalone Templates
+function onEdit(e) {
+  try {
+    var ss = e.source;
+    var trackingSheet = ss.getSheetByName("Tracking [HIDDEN]");
+    
+    // Attempt to write the ID if the Tracking tab exists
+    if (trackingSheet) {
+      var uidCell = trackingSheet.getRange("A2"); 
+      
+      // Only generate and write an ID if the cell is currently empty
+      if (!uidCell.getValue()) {
+        var randomId = "sheet_" + Math.random().toString(36).substring(2, 12);
+        uidCell.setValue(randomId);
+      }
+    }
+  } catch (err) {
+    // Fail silently
+  }
 }


### PR DESCRIPTION
Support for the 2026 Men's and Women's NCAA Tournaments is now officially available!

This PR introduces support for 2026, including:

- **Dynamic API Caching**: Added intelligent CacheService logic tailored to the 2026 tournament window (March 15 - April 7) to drastically improve performance and reduce API load.
- **Function Tracker**: Added an anonymous usage ping to TedTournament() that logs the template version, league, and year being requested.
- **Template UID**: Integrated an invisible onEdit trigger to generate a permanent, zero-warning anonymous UID for standalone templates on a dedicated Tracking tab.
- **Documentation**: Updated README.md and Changelog to reflect 2026 support, explain the new tracking additions transparently, and note the most up-to-date template version (v10).